### PR TITLE
socket STOMP 테스트 완료

### DIFF
--- a/src/main/java/com/kh/saintra/global/config/SecurityConfigure.java
+++ b/src/main/java/com/kh/saintra/global/config/SecurityConfigure.java
@@ -37,10 +37,14 @@ public class SecurityConfigure {
     @Bean
     @Order(1)
     public SecurityFilterChain websocketSecurity(HttpSecurity http) throws Exception {
-        return http.securityMatcher("/ws-status/**","/ws-chat/**")
+        return http.securityMatcher("/ws/**")
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
-                .authorizeHttpRequests(a -> a.anyRequest().authenticated())
+                .authorizeHttpRequests(a -> a.requestMatchers(
+                        HttpMethod.GET, "/ws/**"
+                    ).permitAll()
+                    .anyRequest().authenticated()
+                )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
@@ -56,13 +60,14 @@ public class SecurityConfigure {
                 .cors(Customizer.withDefaults())
                 .sessionManagement(manager -> manager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(requests -> {
-                    requests.requestMatchers(HttpMethod.POST, "api/auth/password", "api/auth/tokens", "api/users/join").permitAll();
-                    requests.requestMatchers(HttpMethod.PATCH, "api/auth/password").permitAll();
+                    requests.requestMatchers(HttpMethod.POST, "/api/auth/password", "/api/auth/tokens", "/api/users/join").permitAll();
+                    requests.requestMatchers(HttpMethod.PATCH, "/api/auth/password").permitAll();
                     requests.requestMatchers(HttpMethod.POST).authenticated();
                     requests.requestMatchers(HttpMethod.GET).authenticated();
                     requests.requestMatchers(HttpMethod.DELETE).authenticated();
                     requests.requestMatchers(HttpMethod.PUT).authenticated();
                     requests.requestMatchers(HttpMethod.PATCH).authenticated();
+                    requests.requestMatchers(HttpMethod.OPTIONS).authenticated();
                 })
                 .addFilterBefore(coopFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/kh/saintra/global/config/WebSocketConfigure.java
+++ b/src/main/java/com/kh/saintra/global/config/WebSocketConfigure.java
@@ -1,11 +1,30 @@
 package com.kh.saintra.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import com.kh.saintra.auth.model.vo.CustomUserDetails;
 import com.kh.saintra.global.config.interceptor.WebSocketHandshakeInterceptor;
+import com.kh.saintra.global.enums.ResponseCode;
+import com.kh.saintra.global.error.exceptions.AuthenticateFailException;
+import com.kh.saintra.global.error.exceptions.AuthenticateTimeOutException;
+import com.kh.saintra.global.error.exceptions.InvalidAccessException;
+import com.kh.saintra.global.util.token.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -14,24 +33,72 @@ import lombok.RequiredArgsConstructor;
 public class WebSocketConfigure implements WebSocketMessageBrokerConfigurer{
 
     private final WebSocketHandshakeInterceptor handshakeInterceptor;
+    private final UserDetailsService userDetailsService;
+    private final JwtUtil jwtUtil;
 
-    @Override
-    public void configureMessageBroker(MessageBrokerRegistry registry) {
-        
-        registry.enableSimpleBroker("/status", "/chat"); // 클라이언트가 구독할 주소
-        registry.setApplicationDestinationPrefixes("/app"); // 클라이언트가 메시지를 보낼 때 접두사
-
-    
-    }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        
+    
         registry.addEndpoint("/ws")
             .setAllowedOriginPatterns("*")
             .addInterceptors(handshakeInterceptor)
             .withSockJS(); //WebSocket 연결 엔드포인트
     }
+
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        
+        // @MessageMapping 메서드로 라우팅할 prefix
+        registry.setApplicationDestinationPrefixes("/app");
+        // 브로커(클라이언트-브로드캐스트)용 prefix
+        registry.enableSimpleBroker("/topic", "/queue");
     
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+                System.out.println("▶ preSend command=" + accessor.getCommand() + ", destination="
+                        + accessor.getDestination()    );
+                // STOMP CONNECT 프레임일 때만 JWT 검사
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    String authHeader = accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION);
+                    if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                        String token = authHeader.substring(7);
+                        try {
+                            // 토큰 파싱 & 검증
+                            Claims claims = jwtUtil.parseJwt(token);
+                            String username = claims.getSubject();
+
+                            // UserDetailsService로부터 사용자 정보 로드
+                            CustomUserDetails user = (CustomUserDetails)
+                                userDetailsService.loadUserByUsername(username);
+
+                            // Authentication 객체 생성 & 세팅
+                            UsernamePasswordAuthenticationToken auth =
+                                new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+                            accessor.setUser(auth);
+                            SecurityContextHolder.getContext().setAuthentication(auth);
+
+                        } catch (ExpiredJwtException e) {
+                            throw new AuthenticateTimeOutException(ResponseCode.AUTH_FAIL, "만료된 토큰입니다.");
+                        } catch (JwtException e) {
+                            throw new AuthenticateFailException(ResponseCode.AUTH_FAIL,
+                                    "유효하지 않은 토큰입니다.");
+                        }
+                    } else {
+                        throw new InvalidAccessException(ResponseCode.AUTH_FAIL, "Authorization 헤더(Bearer 토큰)가 없습니다.");
+                    }
+                }
+                return message;
+            }
+        });
+    }
 
 }

--- a/src/main/java/com/kh/saintra/global/config/interceptor/WebSocketHandshakeInterceptor.java
+++ b/src/main/java/com/kh/saintra/global/config/interceptor/WebSocketHandshakeInterceptor.java
@@ -21,7 +21,7 @@ public class WebSocketHandshakeInterceptor implements HandshakeInterceptor{
         if(authentication != null) {
             attributes.put("authentication", authentication); // WebSocket 세션에 저장
         }
-        
+        System.out.println("핸드셰이크 흔들흔들");
         return true; // 핸드셰이크 허용
         
     }

--- a/src/main/java/com/kh/saintra/user/controller/UserSocketController.java
+++ b/src/main/java/com/kh/saintra/user/controller/UserSocketController.java
@@ -1,0 +1,31 @@
+package com.kh.saintra.user.controller;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class UserSocketController {
+    
+    private final SimpMessagingTemplate template;
+
+    
+    @MessageMapping("/chat.test")
+	public void greet() {
+		String text = "[" + getTimestamp() + "] :";
+		System.out.println("▶▶▶ greet() 호출됨");
+		template.convertAndSend("/topic/message", text);
+	}
+
+    private String getTimestamp() {
+		return new SimpleDateFormat("MM/dd/yyyy h:mm:ss a").format(new Date());
+	}
+}


### PR DESCRIPTION
STOMP 를 사용하기 위한 초기 세팅을 했습니다.

처음 연결은 인증을 하지않고 
SUBSCRIBE 시 인증을 하는 방식으로 구현을 해버렸습니다. 그렇기 때문에 Connect Header에  JWT TOKEN을 넣어주어야 합니다.
`{"Authorization":"Bearer  여기 토큰"}` 이런식으로요

`global/config` 경로에 WebSocketConfigure 파일이 있습니다.
엔드포인트는 동일하게 사용하고, configureMessageBroker에서 브로커용 Prefix를 추가할 수 있습니다.

테스트는 user 패키지의 UserSocketController 클래스에 작성해두었습니다..